### PR TITLE
Extract ApiManager functionality to an interface.

### DIFF
--- a/ApiManager.cs
+++ b/ApiManager.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 
 namespace Moosend.API.Client
 {
-    public class ApiManager
+    public class ApiManager : IApiManager
     {
         private static readonly String END_POINT = "http://api.moosend.com";
 

--- a/ApiManager.cs
+++ b/ApiManager.cs
@@ -28,9 +28,9 @@ namespace Moosend.API.Client
             set;
         }
 
-        private CampaignsWrapper _Campaigns;
+        private ICampaignsWrapper _Campaigns;
 
-        public CampaignsWrapper Campaigns
+        public ICampaignsWrapper Campaigns
         {
             get
             {
@@ -42,9 +42,9 @@ namespace Moosend.API.Client
             }
         }
 
-        private SubscribersWrapper _Subscribers;
+        private ISubscribersWrapper _Subscribers;
 
-        public SubscribersWrapper Subscribers
+        public ISubscribersWrapper Subscribers
         {
             get
             {
@@ -56,9 +56,9 @@ namespace Moosend.API.Client
             }
         }
 
-        private MailingListsWrapper _MailingLists;
+        private IMailingListsWrapper _MailingLists;
 
-        public MailingListsWrapper MailingLists
+        public IMailingListsWrapper MailingLists
         {
             get
             {
@@ -70,9 +70,9 @@ namespace Moosend.API.Client
             }
         }
 
-        private SegmentsWrapper _Segments;
+        private ISegmentsWrapper _Segments;
 
-        public SegmentsWrapper Segments
+        public ISegmentsWrapper Segments
         {
             get
             {

--- a/ApiManager.cs
+++ b/ApiManager.cs
@@ -22,6 +22,14 @@ namespace Moosend.API.Client
             this.ApiKey = apiKey;
         }
 
+        public ApiManager(ICampaignsWrapper campaignsWrapper, IMailingListsWrapper mailingListsWrapper, ISubscribersWrapper subscriberWrapper, ISegmentsWrapper segmentsWrapper)
+        {
+            _Campaigns = campaignsWrapper;
+            _MailingLists = mailingListsWrapper;
+            _Subscribers = subscriberWrapper;
+            _Segments = segmentsWrapper;
+        }
+
         public String ApiKey
         {
             get;
@@ -40,6 +48,10 @@ namespace Moosend.API.Client
                 }
                 return _Campaigns;
             }
+            private set
+            {
+                _Campaigns = value;
+            }
         }
 
         private ISubscribersWrapper _Subscribers;
@@ -53,6 +65,10 @@ namespace Moosend.API.Client
                     _Subscribers = new SubscribersWrapper(this);
                 }
                 return _Subscribers;
+            }
+            private set
+            {
+                _Subscribers = value;
             }
         }
 
@@ -68,6 +84,10 @@ namespace Moosend.API.Client
                 }
                 return _MailingLists;
             }
+            private set
+            {
+                _MailingLists = value;
+            }
         }
 
         private ISegmentsWrapper _Segments;
@@ -81,6 +101,10 @@ namespace Moosend.API.Client
                     _Segments = new SegmentsWrapper(this);
                 }
                 return _Segments;
+            }
+            private set
+            {
+                _Segments = value;
             }
         }
 

--- a/IApiManager.cs
+++ b/IApiManager.cs
@@ -5,10 +5,10 @@ namespace Moosend.API.Client
     public interface IApiManager
     {
         string ApiKey { get; set; }
-        CampaignsWrapper Campaigns { get; }
-        MailingListsWrapper MailingLists { get; }
-        SegmentsWrapper Segments { get; }
-        SubscribersWrapper Subscribers { get; }
+        ICampaignsWrapper Campaigns { get; }
+        IMailingListsWrapper MailingLists { get; }
+        ISegmentsWrapper Segments { get; }
+        ISubscribersWrapper Subscribers { get; }
 
         void MakeRequest(HttpMethod method, string path);
         void MakeRequest(HttpMethod method, string path, object parameters);

--- a/IApiManager.cs
+++ b/IApiManager.cs
@@ -1,0 +1,18 @@
+﻿using Moosend.API.Client.Wrappers;
+
+namespace Moosend.API.Client
+{
+    public interface IApiManager
+    {
+        string ApiKey { get; set; }
+        CampaignsWrapper Campaigns { get; }
+        MailingListsWrapper MailingLists { get; }
+        SegmentsWrapper Segments { get; }
+        SubscribersWrapper Subscribers { get; }
+
+        void MakeRequest(HttpMethod method, string path);
+        void MakeRequest(HttpMethod method, string path, object parameters);
+        T MakeRequest<T>(HttpMethod method, string path);
+        T MakeRequest<T>(HttpMethod method, string path, object parameters);
+    }
+}

--- a/Moosend.API.Client.csproj
+++ b/Moosend.API.Client.csproj
@@ -258,6 +258,10 @@
     <Compile Include="Utilities.cs" />
     <Compile Include="Wrappers\CampaignsWrapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Wrappers\ICampaignsWrapper.cs" />
+    <Compile Include="Wrappers\IMailingListsWrapper.cs" />
+    <Compile Include="Wrappers\ISegmentsWrapper.cs" />
+    <Compile Include="Wrappers\ISubscribersWrapper.cs" />
     <Compile Include="Wrappers\SegmentsWrapper.cs" />
     <Compile Include="Wrappers\MailingListsWrapper.cs" />
     <Compile Include="Wrappers\SubscribersWrapper.cs" />

--- a/Moosend.API.Client.csproj
+++ b/Moosend.API.Client.csproj
@@ -54,6 +54,7 @@
     <Compile Include="ApiResult.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="IApiManager.cs" />
     <Compile Include="Models\CampaignParams.cs" />
     <Compile Include="Models\CampaignStatisticsSummary.cs" />
     <Compile Include="Models\ContextAnalyticsNode.cs" />

--- a/Wrappers/CampaignsWrapper.cs
+++ b/Wrappers/CampaignsWrapper.cs
@@ -7,7 +7,7 @@ using Moosend.API.Client.Serialization;
 
 namespace Moosend.API.Client.Wrappers
 {
-    public class CampaignsWrapper
+    public class CampaignsWrapper : ICampaignsWrapper
     {
         private IApiManager _Manager;
 

--- a/Wrappers/CampaignsWrapper.cs
+++ b/Wrappers/CampaignsWrapper.cs
@@ -9,9 +9,9 @@ namespace Moosend.API.Client.Wrappers
 {
     public class CampaignsWrapper
     {
-        private ApiManager _Manager;
+        private IApiManager _Manager;
 
-        internal CampaignsWrapper(ApiManager manager)
+        internal CampaignsWrapper(IApiManager manager)
         {
             _Manager = manager;
         }

--- a/Wrappers/ICampaignsWrapper.cs
+++ b/Wrappers/ICampaignsWrapper.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using Moosend.API.Client.Models;
+
+namespace Moosend.API.Client.Wrappers
+{
+    public interface ICampaignsWrapper
+    {
+        Campaign Clone(Guid campaignID);
+        Guid Create(CampaignParams campaignParams);
+        void Delete(Guid campaignID);
+        PagedList<CampaignSummary> FindAll(int page = 1, int pageSize = 10);
+        Campaign FindByID(Guid campaignID);
+        Sender FindSender(string email);
+        PagedList<ContextAnalyticsNode> GetActivityByLocation(Guid campaignID);
+        PagedList<ContextAnalyticsNode> GetLinkActivity(Guid campaignID);
+        IList<Sender> GetSenders();
+        PagedList<ContextAnalyticsNode> GetStatistics(Guid campaignID, MailStatus type = MailStatus.Sent, int page = 1, int pageSize = 50, DateTime? from = default(DateTime?), DateTime? to = default(DateTime?));
+        CampaignStatisticsSummary GetSummary(Guid campaignID);
+        void Save(Campaign campaign);
+        void Send(Guid campaignID);
+        void SendTest(Guid campaignID, IList<string> emails);
+        void Update(Campaign campaign);
+    }
+}

--- a/Wrappers/IMailingListsWrapper.cs
+++ b/Wrappers/IMailingListsWrapper.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Moosend.API.Client.Models;
+
+namespace Moosend.API.Client.Wrappers
+{
+    public interface IMailingListsWrapper
+    {
+        Guid Create(string name, string confirmationPage = null, string redirectAfterUnsubscribePage = null);
+        Guid CreateCustomField(Guid mailingListID, string name, CustomFieldType type, bool isRequired, string context = null);
+        void Delete(Guid mailingListID);
+        void DeleteCustomField(Guid mailingListID, Guid customFieldID);
+        PagedList<MailingList> FindAllActive(int page = 1, int pageSize = 10);
+        MailingList FindByID(Guid mailingListID, bool withStatistics = true);
+        PagedList<Subscriber> GetSubscribers(Guid mailingListID, SubscribeType status, DateTime? since = default(DateTime?), int page = 1, int pageSize = 500);
+        void Save(MailingList list);
+        Guid Update(MailingList list);
+        void UpdateCustomField(Guid mailingListID, CustomFieldDefinition customField);
+    }
+}

--- a/Wrappers/ISegmentsWrapper.cs
+++ b/Wrappers/ISegmentsWrapper.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using Moosend.API.Client.Models;
+
+namespace Moosend.API.Client.Wrappers
+{
+    public interface ISegmentsWrapper
+    {
+        void Delete(Guid mailingListID, int segmentID);
+        IList<Segment> FindAllForMailingList(Guid mailingListID);
+        Segment FindByID(Guid mailingListID, int segmentID);
+        PagedList<Subscriber> GetMembers(Segment segment, SubscribeType status = SubscribeType.Subscribed, int page = 1, int pageSize = 500);
+        PagedList<Subscriber> GetMembers(Guid mailingListID, int segmentID, SubscribeType status = SubscribeType.Subscribed, int page = 1, int pageSize = 500);
+        void Save(Segment segment);
+    }
+}

--- a/Wrappers/ISubscribersWrapper.cs
+++ b/Wrappers/ISubscribersWrapper.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using Moosend.API.Client.Models;
+
+namespace Moosend.API.Client.Wrappers
+{
+    public interface ISubscribersWrapper
+    {
+        Subscriber GetByEmail(Guid mailingListID, string email);
+        void Remove(Guid mailingListID, string email);
+        void Remove(Guid mailingListID, IList<string> emails);
+        Subscriber Subscribe(Guid mailingListID, SubscriberParams member);
+        IList<Subscriber> Subscribe(Guid mailingListID, IList<SubscriberParams> members);
+        void Unsubscribe(Guid mailingListID, Guid campaignID, string email);
+    }
+}

--- a/Wrappers/MailingListsWrapper.cs
+++ b/Wrappers/MailingListsWrapper.cs
@@ -8,7 +8,7 @@ using Moosend.API.Client.Serialization;
 
 namespace Moosend.API.Client.Wrappers
 {
-    public class MailingListsWrapper
+    public class MailingListsWrapper : IMailingListsWrapper
     {
         private IApiManager _Manager;
 

--- a/Wrappers/MailingListsWrapper.cs
+++ b/Wrappers/MailingListsWrapper.cs
@@ -10,9 +10,9 @@ namespace Moosend.API.Client.Wrappers
 {
     public class MailingListsWrapper
     {
-        private ApiManager _Manager;
+        private IApiManager _Manager;
 
-        internal MailingListsWrapper(ApiManager manager)
+        internal MailingListsWrapper(IApiManager manager)
         {
             _Manager = manager;
         }

--- a/Wrappers/SegmentsWrapper.cs
+++ b/Wrappers/SegmentsWrapper.cs
@@ -7,7 +7,7 @@ using Moosend.API.Client.Serialization;
 
 namespace Moosend.API.Client.Wrappers
 {
-    public class SegmentsWrapper
+    public class SegmentsWrapper : ISegmentsWrapper
     {
         private IApiManager _Manager;
 

--- a/Wrappers/SegmentsWrapper.cs
+++ b/Wrappers/SegmentsWrapper.cs
@@ -9,9 +9,9 @@ namespace Moosend.API.Client.Wrappers
 {
     public class SegmentsWrapper
     {
-        private ApiManager _Manager;
+        private IApiManager _Manager;
 
-        internal SegmentsWrapper(ApiManager manager)
+        internal SegmentsWrapper(IApiManager manager)
         {
             _Manager = manager;
         }

--- a/Wrappers/SubscribersWrapper.cs
+++ b/Wrappers/SubscribersWrapper.cs
@@ -9,9 +9,9 @@ namespace Moosend.API.Client.Wrappers
 {
     public class SubscribersWrapper
     {
-        private ApiManager _Manager;
+        private IApiManager _Manager;
 
-        internal SubscribersWrapper(ApiManager manager)
+        internal SubscribersWrapper(IApiManager manager)
         {
             _Manager = manager;
         }

--- a/Wrappers/SubscribersWrapper.cs
+++ b/Wrappers/SubscribersWrapper.cs
@@ -7,7 +7,7 @@ using System.Web;
 
 namespace Moosend.API.Client.Wrappers
 {
-    public class SubscribersWrapper
+    public class SubscribersWrapper : ISubscribersWrapper
     {
         private IApiManager _Manager;
 

--- a/readme.md
+++ b/readme.md
@@ -51,10 +51,10 @@ Include the following using statements for your convinience
 	using Moosend.API.Client.Models;
 ```
 
-Make a declaration like the following in your class to access the API
+Make a declaration like the following in your class to access the API (or even better use DI to inject using your favorite IoC library)
 
 ```c#
-	private ApiManager MoosendAPI = new ApiManager("YOUR_API_KEY");
+	private IApiManager MoosendAPI = new ApiManager("YOUR_API_KEY");
 ```
 
 Examples


### PR DESCRIPTION
ApiManager is now mockable, enabling easier unit testing of libraries referencing it.
